### PR TITLE
Fix order of posts in postsWithTag and postsWithCategory

### DIFF
--- a/lib/poet/core.js
+++ b/lib/poet/core.js
@@ -65,24 +65,26 @@ function getPageCount () {
 
 function postsWithTag ( tag ) {
   if ( storage.postsTagged[ tag ] ) return storage.postsTagged[ tag ];
+
   var ret = [];
-  for ( var p in storage.posts ) {
-    if ( !storage.posts[ p ].tags ) continue;
-    if ( ~storage.posts[ p ].tags.indexOf( tag )) {
-      ret.push( storage.posts[ p ] );
+    storage.orderedPosts.forEach(function(p) {
+    if (p.tags && ~p.tags.indexOf( tag )) {
+      ret.push( p );
     }
-  }
+  });
+
   return storage.postsTagged[ tag ] = ret;
 }
 
 function postsWithCategory ( cat ) {
   if ( storage.postsCategorized[ cat ] ) return storage.postsCategorized[ cat ];
+
   var ret = [];
-  for ( var p in storage.posts ) {
-    if ( !storage.posts[ p ].category ) continue;
-    if ( storage.posts[ p ].category.toLowerCase() === cat.toLowerCase()) {
-      ret.push( storage.posts[ p ] );
+    storage.orderedPosts.forEach(function(p) {
+    if ( p.category && p.category.toLowerCase() === cat.toLowerCase() ) {
+      ret.push( p );
     }
-  }
+  });
+
   return storage.postsCategorized[ cat ] = ret;
 }

--- a/test/order.test.js
+++ b/test/order.test.js
@@ -1,0 +1,39 @@
+var
+  express = require( 'express' ),
+  chai    = require( 'chai' ),
+  should  = chai.should(),
+  expect  = chai.expect;
+
+describe( 'core.postWithTag()', function () {
+  it( 'should return posts ordered by date, newest first', function ( done ) {
+    var
+      app = express.createServer(),
+      poet = require( '../lib/poet' )( app );
+
+    poet.set({ posts: './test/_postsJson' }).init(function ( core ) {
+      var posts = core.postsWithTag('a');
+      
+      (posts[0].date.getTime() > posts[1].date.getTime()).should.equal(true);
+      (posts[1].date.getTime() > posts[2].date.getTime()).should.equal(true);
+      
+      done();
+    });
+  });
+});
+
+describe( 'core.postWithCategories()', function () {
+  it( 'should return posts ordered by date, newest first', function ( done ) {
+    var
+      app = express.createServer(),
+      poet = require( '../lib/poet' )( app );
+
+    poet.set({ posts: './test/_postsJson' }).init(function ( core ) {
+      var posts = core.postsWithCategory('testing');
+      
+      (posts[0].date.getTime() > posts[1].date.getTime()).should.equal(true);
+      (posts[1].date.getTime() > posts[2].date.getTime()).should.equal(true);
+      
+      done();
+    });
+  });
+});


### PR DESCRIPTION
previously the creation of storage.postsTagged[ tag] was using storage.posts.
I changed it to use storage.orderedPosts so the returned value will be ordered by date.
