### PR TITLE
Add "previewLength" as a metadata to post

### DIFF
--- a/lib/poet.js
+++ b/lib/poet.js
@@ -108,7 +108,8 @@ function saveData ( err, data, file, template, callback ) {
   var
     t = options.metaFormat( data ),
     fileName = file.replace( /\.[^\.]*$/, '' ),
-    post = storage.posts[ fileName ] = {};
+    post = storage.posts[ fileName ] = {},
+    lengthDefinedPreview;
   Object.keys( t.attributes ).forEach(function ( p ) {
     if ( p === 'date' )
       post[ p ] = new Date( t.attributes[ p ] );
@@ -121,7 +122,8 @@ function saveData ( err, data, file, template, callback ) {
   post.content = template( t.body );
   post.slug = fileName;
   post.url = options.routes.post.match( /[^\:]*/ )[0] + fileName;
-  post.preview = template( post.preview || t.body.replace(/\n.*/g, ''));
+  lengthDefinedPreview = post.previewLength ? t.body.substr(0, post.previewLength) + ' (...)' : undefined;
+  post.preview = template( post.preview || lengthDefinedPreview || t.body.replace(/\n.*/g, ''));
   callback();
 }
 


### PR DESCRIPTION
This little modification lets you define how many characters should appear in a post's preview snippet.
Usage is simple:
`{{{
  "title" : "Starting a Blog with Node.js and Poet",
  "tags"  : [ "blog", "node", "static", "generator", "poet", "en" ],
  "category" : "javascript",
  "date" : "10-22-2012",
  "previewLength": "300"
}}}`
