### PR TITLE
support for tag pages in getPageCount

### DIFF
--- a/lib/poet/core.js
+++ b/lib/poet/core.js
@@ -59,8 +59,12 @@ function pageUrl ( page ) {
   return utils.stripRouteParams( options.routes.page ) + page;
 }
 
-function getPageCount () {
-  return Math.ceil( storage.orderedPosts.length / options.postsPerPage );
+function getPageCount ( tag ) {
+  if (tag) {
+    return Math.ceil( postsWithTag(tag).length / options.postsPerPage );
+  } else {
+    return Math.ceil( storage.orderedPosts.length / options.postsPerPage );
+  }
 }
 
 function postsWithTag ( tag ) {


### PR DESCRIPTION
currently getPageCount only return number for the index pages.
I added support for tag pages as well, so if you have pagination on those it will work as expected.
