### PR TITLE
Add "showDrafts" as an option to hide posts tagged with "draft"

### DIFF
--- a/lib/poet.js
+++ b/lib/poet.js
@@ -20,6 +20,8 @@ module.exports = function poet ( _app ) {
   options = {
     postsPerPage : 5,
     posts        : './_posts/',
+    showDrafts   : false,
+    draftTag     : 'draft',
     metaFormat   : jsonFm,
     readMoreLink : function ( post ) {
       var anchor = '<a href="'+post.url+'" title="Read more of '+post.title+'">read more</a>';
@@ -118,6 +120,7 @@ function saveData ( err, data, file, template, callback ) {
     post = storage.posts[ fileName ] = {},
     lengthDefinedPreview,
     readMoreDefinedPreview;
+
   Object.keys( attributes ).forEach(function ( p ) {
     if ( p === 'date' )
       post[ p ] = new Date( attributes[ p ] );

--- a/lib/poet/core.js
+++ b/lib/poet/core.js
@@ -36,15 +36,27 @@ module.exports = function ( _options, _storage ) {
 };
 
 function getPostCount () {
-  return storage.orderedPosts.length;
+  return getPosts().length;
 }
 
 function getPost ( title ) {
   return storage.posts[ title ];
 }
 
-function getPosts ( from, to ) {
-  return storage.orderedPosts.slice( from, to );
+function getPosts ( from, to ) {   
+  var posts = storage.orderedPosts;
+
+  if (options.showDrafts === false) {
+    posts = posts.filter(function(post){
+      return !utils.isPostDraft(post, options.draftTag);        
+    });
+  }
+
+  if (from != undefined && to != undefined) {
+    posts = posts.slice( from, to );
+  }
+
+  return posts;
 }
 
 function tagUrl ( tag ) {
@@ -60,7 +72,7 @@ function pageUrl ( page ) {
 }
 
 function getPageCount () {
-  return Math.ceil( storage.orderedPosts.length / options.postsPerPage );
+  return Math.ceil( getPosts().length / options.postsPerPage );
 }
 
 function postsWithTag ( tag ) {

--- a/lib/poet/utils.js
+++ b/lib/poet/utils.js
@@ -28,3 +28,12 @@ exports.getPreview = function ( post, body, options ) {
 
   return body.replace( /\n.*/g, '' );
 };
+
+exports.isPostDraft = function ( post, draftTag ) {
+  var isDraft = false;
+  if (post.tags)
+    post.tags.forEach(function(tag){ 
+      if (tag === draftTag) isDraft = true;
+    });
+  return isDraft;
+}


### PR DESCRIPTION
Added a small functionality to hide the draft articles. They can still be viewed by searching for the "draft" tag, because I have nothing against public drafts.

Thanks for the awesome framework, as I work more deeply inside it, I appreciate even more the elegant solutions used.
