### PR TITLE
Export options in core object

### DIFF
--- a/lib/poet/core.js
+++ b/lib/poet/core.js
@@ -31,7 +31,11 @@ module.exports = function ( _options, _storage ) {
     // Pages
 
     getPageCount : getPageCount,
-    pageUrl      : pageUrl
+    pageUrl      : pageUrl,
+    
+    // Options
+    
+    options : options
   };
 };
 


### PR DESCRIPTION
allow middleware to access options like postsPerPage that are
set, but inaccessible to functions like handmade routes.
