### PR TITLE
Recursive directory search for posts

### DIFF
--- a/lib/poet.js
+++ b/lib/poet.js
@@ -125,8 +125,8 @@ function saveData ( err, data, dir, file, template, callback ) {
     t = options.metaFormat( data ),
     body = t.body,
     attributes = t.attributes,
-    fileName = (dir + file).replace( /(\.[^\.]*$|\.+)/g, '' )
-                           .replace ( /(\/+)/g, '_' ),
+    fileName = (dir + file).replace( /((\/)?.*?\/|\.[^\.]*$|\.+)/g, '' )
+                           .replace( /\/+/g, '_'),
     post = storage.posts[ fileName ] = {},
     lengthDefinedPreview,
     readMoreDefinedPreview;


### PR DESCRIPTION
This should allow for use of directories in your posts folder.

The slug has the directory path added onto the name.

It's useful for someone who has multiple github projects, you could git submodule the wikis of those projects into the posts directory and have poet as a markdown blog of all your project wikis.
