### PR TITLE
save raw preview text before modification

### DIFF
--- a/lib/poet.js
+++ b/lib/poet.js
@@ -129,6 +129,7 @@ function saveData ( err, data, file, template, callback ) {
   }
   post.content = template( body );
   post.slug = fileName;
+  post.rawPreview = post.preview;
   post.url = options.routes.post.match( /[^\:]*/ )[0] + fileName;
   post.preview = template( utils.getPreview( post, body, options ) );
   post.preview += options.readMoreLink( post );


### PR DESCRIPTION
saves the raw preview text to a property "rawPreview" prior to the preview being modified and encoded to HTML.
