### PR TITLE
Pass null as the initial value to reduce

### DIFF
--- a/lib/poet/utils.js
+++ b/lib/poet/utils.js
@@ -259,7 +259,7 @@ exports.getRouteType = getRouteType;
 function getRoute (routes, type) {
   return Object.keys(routes).reduce(function (match, route) {
     return getRouteType(route) === type ? route : match;
-  });
+  }, null);
 }
 exports.getRoute = getRoute;
 


### PR DESCRIPTION
This fix is required because calling `getRoute` with an invalid route currently returns the first type in `Object.keys(poet.options.routes)`. This can be demonstrated by called `addRoute` with an invalid route, e.g.

```
poet.addRoute("/", function(request, response) {
    response.render("index");
}
```
