### PR TITLE
Include extra options provided by user

### DIFF
--- a/lib/poet/utils.js
+++ b/lib/poet/utils.js
@@ -30,9 +30,9 @@ function createOptions (options) {
   }, {});
 
   for (key in options) {
-      if (!union.hasOwnProperty(key)) {
-	  union[key] = options[key];
-      }
+    if (!union.hasOwnProperty(key)) {
+      union[key] = options[key];
+    }
   }
 
   return union;


### PR DESCRIPTION
It would be nice to allow the user to provide extra options to the Poet constructor and have them included in `poet.options`. One possible example where this would prove useful is for storing the name of the blog and then passing it to the jade template for each view. This would allow the user to have a different title for each view (e.g. `Page n | Blog Title` and `Post Title | Blog Title`) instead of having one title for every page in the blog.

The way I've implemented this is slightly messy, but I hope you'll accept the idea even if you don't accept the pull request.
