### PR TITLE
Pass null as the initial value to reduce.

### DIFF
--- a/lib/poet/utils.js
+++ b/lib/poet/utils.js
@@ -259,7 +259,7 @@ exports.getRouteType = getRouteType;
 function getRoute (routes, type) {
   return Object.keys(routes).reduce(function (match, route) {
     return getRouteType(route) === type ? route : match;
-  });
+  }, null);
 }
 exports.getRoute = getRoute;
 

--- a/test/routes.test.js
+++ b/test/routes.test.js
@@ -95,7 +95,34 @@ describe('Routes', function () {
       done();
     });
   });
-  
+
+  it('should allow manually added routes', function(done) {
+    var
+      app = express(),
+      poet = Poet(app),
+      handler = function (request, response) {};
+
+    poet.addRoute('/myposts/:post', handler);
+    poet.addRoute('/pagesss/:page', handler);
+    poet.addRoute('/mytags/:tag', handler);
+    poet.addRoute('/mycats/:category', handler);
+    poet.addRoute('/', handler);
+
+    poet.init();
+
+    routeInfo.getCallback(app, '/myposts/:post')
+      .should.equal(handler);
+    routeInfo.getCallback(app, '/pagesss/:page')
+      .should.equal(handler);
+    routeInfo.getCallback(app, '/mytags/:tag')
+      .should.equal(handler);
+    routeInfo.getCallback(app, '/mycats/:category')
+      .should.equal(handler);
+    routeInfo.getCallback(app, '/')
+      .should.equal(handler);
+    done();
+  });
+
   it('should use configurable views', function ( done ) {
     var
       app = express(),


### PR DESCRIPTION
This fix is required because calling `getRoute` with an invalid route currently returns the first type in `Object.keys(poet.options.routes)`. This can be demonstrated by called `addRoute` with an invalid route, e.g.

```
poet.addRoute("/", function(request, response) {
    response.render("index");
}
```
