### PR TITLE
Asynchronous loading of templates

### DIFF
--- a/lib/poet/methods.js
+++ b/lib/poet/methods.js
@@ -4,7 +4,7 @@ var
   path = require('path'),
   defer = require('when').defer,
   all = require('when').all,
-  callbacks = require('when/callbacks'),
+  nodefn = require('when/node/function'),
   fsThen = require('fs-then'),
   utils = require('./utils');
 
@@ -55,14 +55,19 @@ function init (poet, callback) {
       if (!template) return coll;
 
       // If template function accepts more than one argument, then handle 2nd 
-      // argument as asynchronous callback function 
-      if (template.length > 1)
-        template = callbacks.call.bind(callbacks, template);
+      // argument as asynchronous node-style callback function 
+      if (template.length > 1) {
+        template = function(template, string) {
+          var result = defer();
+          template(string, nodefn.createCallback(result.resolver));
+          return result.promise;
+        }.bind(null, template);
+      }
 
       // Do the templating and adding to poet instance
       // here for access to the file name
       var post = utils.createPost(file, options).then(function (post) {
-        return all([template(post.content), template(post.preview)]).then(function (contents) {
+        return all([template(post.content), template(post.preview)]).then(function (contents) {	 
           post.content = contents[0];
           post.preview = contents[1] + options.readMoreLink(post);
           poet.posts[post.slug] = post;

--- a/test/templates.test.js
+++ b/test/templates.test.js
@@ -61,6 +61,26 @@ describe('Templating', function () {
     }).then(null, done);
   });
 
+  it('should correctly render with any custom formatter asynchronously', function (done) {
+    var
+      app = express(),
+      poet = Poet(app, {
+        posts: './test/_postsJson'
+      });
+    
+    poet.addTemplate({
+      ext: 'custom',
+      fn: function (s, callback) {
+        callback(null, s.replace(/\*(.*?)\*/g, '<$1>'));
+      }
+    }).init().then(function () {
+      var posts = poet.posts;
+      posts['customTemplate'].content.should.contain(pEl);
+      posts['customTemplate'].content.should.contain(h1El);
+      done();
+    }).then(null, done);
+  });
+
   it('markdown should not strip out HTML elements', function () {
     var
       app = express(),


### PR DESCRIPTION
For our blog I really wanted to use pygmentize for syntax highlighting (in combination with marked).
However, pygmentize only supports asynchronous loading and poet's current templating method did not.

I changed the functionality so that when a second argument is present in a template function it will be considered as a node-style asynchronous callback (aka callback(err, result)). 

For existing/default installations nothing has changed. So the new asynchronous callback style should definitely be opt-in only :)

Example async callback with markdown & pygmentize:

``` javascript

var Poet = require('poet'),
    marked = require('marked'),
    pygmentize = require('pygmentize-bundled');

var poet = Poet(app, {
  ...
});

var markedOptions = {
  ...
  highlight: function (code, lang, callback) {
    pygmentize({ lang: lang, format: 'html' }, code, function (err, result) {
      if (err) return callback(err);
      callback(null, result.toString());
    });
  }
};

poet.addTemplate({
  ext: ['md', 'markdown'],
  fn: function (string, callback) { marked(string, markedOptions, callback); }
});

```
