### PR TITLE
Handle errors while parsing posts.

### DIFF
--- a/lib/poet/methods.js
+++ b/lib/poet/methods.js
@@ -54,8 +54,8 @@ function init (poet, callback) {
       // If no template found, ignore (swap file, etc.)
       if (!template) return coll;
 
-      // If template function accepts more than one argument, then handle 2nd 
-      // argument as asynchronous node-style callback function 
+      // If template function accepts more than one argument, then handle 2nd
+      // argument as asynchronous node-style callback function
       if (template.length > 1) {
         template = function(template, string) {
           var result = defer();
@@ -67,14 +67,19 @@ function init (poet, callback) {
       // Do the templating and adding to poet instance
       // here for access to the file name
       var post = utils.createPost(file, options).then(function (post) {
-        return all([template(post.content), template(post.preview)]).then(function (contents) {	 
+        return all([template(post.content), template(post.preview)]).then(function (contents) {
           post.content = contents[0];
           post.preview = contents[1] + options.readMoreLink(post);
           poet.posts[post.slug] = post;
         });
+      }, function (reason) {
+          console.log("Unable to parse file " + file + " because: " + reason);
+          post = undefined;
       });
 
-      coll.push(post);
+      if ( post != undefined ) {
+        coll.push(post);
+      }
       return coll;
     }, []);
 
@@ -94,7 +99,7 @@ function init (poet, callback) {
 exports.init = init;
 
 /**
- * Clears the `poet` instance's 'cache' object -- useful when modifying 
+ * Clears the `poet` instance's 'cache' object -- useful when modifying
  * posts dynamically
  *
  * @params {Object} poet


### PR DESCRIPTION
Fixes https://github.com/jsantell/poet/issues/59 by adding a second callback argument to `.then` for failure cases.
