### PR TITLE
Add method `unwatch` to remove all registered watchers

### DIFF
--- a/lib/poet.js
+++ b/lib/poet.js
@@ -25,6 +25,9 @@ function Poet (app, options) {
   // Construct helper methods
   this.helpers = createHelpers(this);
 
+  // Initialize empty watchers list
+  this.watchers = [];
+
   // Bind locals for view access
   utils.createLocals(this.app, this.helpers);
 
@@ -41,3 +44,4 @@ Poet.prototype.init = method(methods.init);
 Poet.prototype.clearCache = method(methods.clearCache);
 Poet.prototype.addRoute = method(routes.addRoute);
 Poet.prototype.watch = method(methods.watch);
+Poet.prototype.unwatch = method(methods.unwatch);

--- a/lib/poet/methods.js
+++ b/lib/poet/methods.js
@@ -114,11 +114,24 @@ exports.clearCache = clearCache;
  * @params {function} [callback]
  * @returns {Poet}
  */
-
 function watch (poet, callback) {
-  fs.watch(poet.options.posts, function (event, filename) {
+  var watcher = fs.watch(poet.options.posts, function (event, filename) {
     poet.init().then(callback);
   });
+  poet.watchers.push(watcher);
   return poet;
 }
 exports.watch = watch;
+
+/**
+ * Removes all watchers from the `poet` instance so previously registered
+ * callbacks are not called again
+ */
+function unwatch (poet) {
+  poet.watchers.forEach(function (watcher) {
+    watcher.close();
+  });
+  poet.watchers = [];
+  return poet;
+}
+exports.unwatch = unwatch;


### PR DESCRIPTION
To use, call `unwatch` on a `Poet` instance without arguments. Every previously registered watcher (using `watch(...)`) is immediately `close`d, clearing it from the event queue.

Fixes #67

Tests are not included as `watch` don't have tests and I really didn't know how to test this.
