### PR TITLE
Made possible to use custom slugs

### DIFF
--- a/lib/poet/utils.js
+++ b/lib/poet/utils.js
@@ -171,7 +171,7 @@ function createPost (filePath, options) {
     var parsed = (options.metaFormat === 'yaml' ? yamlFm : jsonFm)(data);
     var body = parsed.body;
     var post = parsed.attributes;
-    var shortName = fileName.replace(/\.[^\.]*$/, '');
+    var shortName = post.slug || fileName.replace(/\.[^\.]*$/, '');
 
     // If no date defined, create one for current date
     post.date = new Date(post.date);

--- a/test/_postsJson/test1.md
+++ b/test/_postsJson/test1.md
@@ -3,7 +3,8 @@
   "tags" : [ "a", "b" ],
   "category" : "testing",
   "date" : "7-10-2012",
-  "arbitrary" : "arbitrary content"
+  "arbitrary" : "arbitrary content",
+  "slug": "test-one"
 }}}
 
 *Lorem ipsum* dolor sit amet, consectetur adipisicing elit.

--- a/test/_postsYaml/test1.md
+++ b/test/_postsYaml/test1.md
@@ -6,6 +6,7 @@ tags:
 category: testing
 date: 7-10-2012
 arbitrary: arbitrary content
+slug: test-one
 ---
 
 *Lorem ipsum* dolor sit amet, consectetur adipisicing elit.

--- a/test/init.test.js
+++ b/test/init.test.js
@@ -14,7 +14,7 @@ describe('Init', function () {
       });
 
     poet.init().then(function () {
-      expect(poet.posts['test1']).to.be.ok;
+      expect(poet.posts['test-one']).to.be.ok;
       expect(poet.helpers.getPosts().length).to.be.ok;
       done();
     }).then(null, done);

--- a/test/posts.test.js
+++ b/test/posts.test.js
@@ -8,7 +8,7 @@ var
 var
   postPreview = '<p><em>Lorem ipsum</em> dolor sit amet, consectetur adipisicing elit.</p>',
   postBody    = '<p><em>Lorem ipsum</em> dolor sit amet, consectetur adipisicing elit.</p>\n<h1>Header 1</h1>\n',
-  readMoreAnchorp1 = '<p><a href="/post/test1" title="Read more of Test Post One">read more</a></p>',
+  readMoreAnchorp1 = '<p><a href="/post/test-one" title="Read more of Test Post One">read more</a></p>',
   readMoreAnchorp2 = '<p><a href="/post/test2" title="Read more of Test Post Two">read more</a></p>';
   readMoreAnchorp3 = '<p><a href="/post/test3" title="Read more of Test Post Three">read more</a></p>';
 
@@ -25,17 +25,17 @@ describe('Posts', function () {
       poet.init().then(function () {
         var posts = poet.helpers.getPosts();
         posts.should.have.length(6);
-        poet.posts['test1'].slug.should.equal('test1');
-        poet.posts['test1'].tags.should.have.length(2);
-        poet.posts['test1'].tags.should.include('a');
-        poet.posts['test1'].tags.should.include('b');
-        poet.posts['test1'].category.should.equal('testing');
-        poet.posts['test1'].url.should.equal('/post/test1');
-        poet.posts['test1'].arbitrary.should.equal('arbitrary content');
+        poet.posts['test-one'].slug.should.equal('test-one');
+        poet.posts['test-one'].tags.should.have.length(2);
+        poet.posts['test-one'].tags.should.include('a');
+        poet.posts['test-one'].tags.should.include('b');
+        poet.posts['test-one'].category.should.equal('testing');
+        poet.posts['test-one'].url.should.equal('/post/test-one');
+        poet.posts['test-one'].arbitrary.should.equal('arbitrary content');
 
         // Also tests HTML rendering
-        poet.posts['test1'].preview.should.equal(postPreview + "\n" + readMoreAnchorp1 );
-        poet.posts['test1'].content.should.equal(postBody);
+        poet.posts['test-one'].preview.should.equal(postPreview + "\n" + readMoreAnchorp1 );
+        poet.posts['test-one'].content.should.equal(postBody);
 
         // All posts should be in order
         posts[5].title.should.equals('Test Post Four - A Draft');
@@ -84,12 +84,12 @@ describe('Posts', function () {
         var posts = poet.helpers.getPosts();
         posts.should.have.length(4);
         posts[2].title.should.equal('Test Post One');
-        posts[2].slug.should.equal('test1');
+        posts[2].slug.should.equal('test-one');
         posts[2].tags.should.have.length(2);
         posts[2].tags.should.include('a');
         posts[2].tags.should.include('b');
         posts[2].category.should.equal('testing');
-        posts[2].url.should.equal('/post/test1');
+        posts[2].url.should.equal('/post/test-one');
         posts[2].arbitrary.should.equal('arbitrary content');
 
         // Also tests HTML rendering

--- a/test/routes.test.js
+++ b/test/routes.test.js
@@ -34,7 +34,7 @@ describe('Routes', function () {
       poet = Poet(app, { posts: './test/_postsJson' });
 
     var
-      reqPost = reqMock({ post: 'test1'}),
+      reqPost = reqMock({ post: 'test-one'}),
       reqPage = reqMock({ page: 1}),
       reqTag = reqMock({ tag: 'a'}),
       reqCategory = reqMock({ category: 'testing' }),
@@ -135,7 +135,7 @@ describe('Routes', function () {
           '/mycats/:category': 'categoryView'
         }
       }),
-      reqPost = reqMock({ post: 'test1'}),
+      reqPost = reqMock({ post: 'test-one'}),
       reqPage = reqMock({ page: 1}),
       reqTag = reqMock({ tag: 'a'}),
       reqCategory = reqMock({ category: 'testing' }),

--- a/test/templates.test.js
+++ b/test/templates.test.js
@@ -19,8 +19,8 @@ describe('Templating', function () {
 
     poet.init().then(function () {
       var posts = poet.posts;
-      posts['test1'].content.should.contain(pEl);
-      posts['test1'].content.should.contain(h1El);
+      posts['test-one'].content.should.contain(pEl);
+      posts['test-one'].content.should.contain(h1El);
       done();
     }).then(null, done);
   });


### PR DESCRIPTION
Having a `slug` in the front matter now sets the `post.slug` and `post.url` to use it.

This should integrate well with with #64, as it overrides whatever the auto-slug is, although tests may have to be re-tweaked.
