### PR TITLE
allow initialization with an empty route collection

### DIFF
--- a/lib/poet/utils.js
+++ b/lib/poet/utils.js
@@ -49,6 +49,9 @@ exports.createOptions = createOptions;
  */
 
 function createURL (route, value) {
+  if (!route) {
+    return '';
+  }
   return encodeURI(route.match(/[^\:]*/)[0] + value);
 }
 exports.createURL = createURL;

--- a/test/routes.test.js
+++ b/test/routes.test.js
@@ -96,6 +96,21 @@ describe('Routes', function () {
     });
   });
 
+  it('should allow empty routes in config', function (done) {
+    var
+      app = express(),
+      poet = Poet(app, {
+        posts: './test/_postsJson',
+        routes: { }
+      });
+
+    poet.init().then(function () {
+      //make sure the posts actually get created
+      Object.keys(poet.posts).should.have.length(6);
+      done();
+    });
+  });
+
   it('should allow manually added routes', function(done) {
     var
       app = express(),


### PR DESCRIPTION
This allows initialization of the `Poet` object with an empty route collection, e.g.

``` javascript
var poet = Poet(app, { 
  posts: '/posts',
  routes: {}
});
```

Currently it just (silently) throws an error and fail to populate the `poet.posts` collection.

This is useful if you want to use poet but use your own custom routes. The `addRoute` method doesn't work in this case, because that only allows you to override, not eliminate routes.

Even if that's not a very common use case, this PR still prevents a `null` error.
