### PR TITLE
Expose template engines for additional configuration

### DIFF
--- a/lib/poet.js
+++ b/lib/poet.js
@@ -1,7 +1,7 @@
 var
   fs = require('fs'),
   _ = require('underscore'),
-  createTemplates = require('./poet/templates'),
+  templateSources = require('./poet/templates'),
   createHelpers = require('./poet/helpers'),
   routes = require('./poet/routes'),
   methods = require('./poet/methods'),
@@ -20,7 +20,10 @@ function Poet (app, options) {
   this.options = utils.createOptions(options);
 
   // Set up default templates (markdown, jade)
-  this.templates = createTemplates();
+  this.templates = templateSources.templates;
+
+  // Template engines are exposed so you may do additional configuration
+  this.templateEngines = templateSources.templateEngines;
 
   // Construct helper methods
   this.helpers = createHelpers(this);

--- a/lib/poet/templates.js
+++ b/lib/poet/templates.js
@@ -9,19 +9,14 @@ markdown.setOptions({
   pedantic: true
 });
 
-/**
- * Returns a fresh copy of default templates. A template function accepts an
- * options object that should have at least a `source` field. A second argument
- * can be a callback in case the compilation is asynchronous.
- *
- * @returns {Object}
- */
-
-function createTemplates () {
-  return {
+module.exports = {
+  templates: {
     jade: function (options) { return jade(options.source, {filename: options.filename})(options.locals); },
     markdown: function (options) { return markdown(options.source); },
     md: function (options) { return markdown(options.source); }
-  };
-}
-module.exports = createTemplates;
+  },
+  templateEngines: {
+    marked: markdown,
+    jade: jade
+  }
+};

--- a/test/templates.test.js
+++ b/test/templates.test.js
@@ -156,6 +156,22 @@ describe('Templating', function () {
         done();
       }).then(null, done);
     });
+  });
 
+  it('should expose registered template engines on templateEngines', function () {
+    var
+      app = express(),
+      poet = Poet(app, {
+        posts: './test/_postsJson'
+      });
+
+    poet.templateEngines.marked.setOptions({
+      sanitize: true
+    });
+
+    poet.init().then(function () {
+      var posts = poet.posts;
+      posts['test-post-three'].content.should.not.contain(scriptBody);
+    });
   });
 });


### PR DESCRIPTION
I wanted to add highlighting to the included markdown processor, but was disappointed to find it's not exposed so I can configure it! It feels like a waste to have to include markdown myself again or require poet's `marked`. This exposes the two included templating engines, jade and marked.
