### PR TITLE
Hide "read more" option in a post

### DIFF
--- a/lib/poet/defaults.js
+++ b/lib/poet/defaults.js
@@ -2,6 +2,15 @@ var
   _ = require('underscore');
 
 function readMoreLink (post) {
+ /* if no "read more" is wanted in the post 
+  * set "previewLength" equal to sentinel value of 314159 
+  * (can be made different) and actual post in a list of 
+  * posts won't show link to the whole post 
+  */
+  if(post.previewLength == 314159){
+    return '<p></p>';
+  } 
+
   var anchor = '<a href="' + post.url + '"';
   anchor += ' title="Read more of ' + post.title + '">read more</a>';
   return '<p>' + anchor + '</p>';


### PR DESCRIPTION
Set property "readMoreLength" to 314159 (can be changed) and "read more" will not show in a post when viewing it in list of posts.
Implementetation is probably ugly, so please, suggest better fix (since I'm still learning).

Thanks.
