### PR TITLE
Restricted Express version to < 4 and updated marked version. 

### DIFF
--- a/lib/poet/templates.js
+++ b/lib/poet/templates.js
@@ -1,10 +1,16 @@
 var
   _ = require('underscore'),
   markdown = require('marked'),
+  renderer = new markdown.Renderer(),
   jade = require('jade').compile;
+
+renderer.heading = function(text, level) {
+  return '<h' + level + '>' + text + '</h' + level + '>\n';
+};
 
 // Configure defaults for marked to keep compatibility
 markdown.setOptions({
+  renderer: renderer,
   sanitize: false,
   pedantic: true
 });

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.1",
   "main": "lib/poet",
   "dependencies": {
-    "marked": "0.2.8",
+    "marked": "~0.3.2",
     "jade": ">= 0.27.1",
     "json-front-matter": ">= 0.1.4",
     "underscore": "1.4.x",


### PR DESCRIPTION
Res.locals is no longer a function in express which breaks all tests. Excluded it from package.json pending a fix to support Express 4+. Also updated Marked to 3.2 which adds the ability to customize the renderer.
