### PR TITLE
`app.locals` is not a function in express 4.x any more

### DIFF
--- a/lib/poet/utils.js
+++ b/lib/poet/utils.js
@@ -71,7 +71,8 @@ exports.getPostPaths = getPostPaths;
  */
 
 function createLocals (app, helpers) {
-  app.locals(helpers);
+  if(typeof app.locals==="function") app.locals(helpers);
+  else app.locals = _.extend(app.locals, helpers);
 }
 exports.createLocals = createLocals;
 


### PR DESCRIPTION
As `app.locals` is no longer a function in express 4.x (it's an object instead) `lib/poet/utils.js:74` is an instant crash.

**ref:** `app.locals` in [4x](http://expressjs.com/4x/api.html#app.locals) vs [3x](http://expressjs.com/3x/api.html#app.locals). Also a [migration note](https://github.com/visionmedia/express/wiki/Migrating-from-3.x-to-4.x#reslocals) in that regard.
