### PR TITLE
Added post scheduling for future dates

### DIFF
--- a/lib/poet.js
+++ b/lib/poet.js
@@ -31,6 +31,9 @@ function Poet (app, options) {
   // Initialize empty watchers list
   this.watchers = [];
 
+  // Initialize empty "futures" list
+  this.futures = [];
+
   // Bind locals for view access
   utils.createLocals(this.app, this.helpers);
 

--- a/lib/poet/methods.js
+++ b/lib/poet/methods.js
@@ -99,7 +99,10 @@ function init (poet, callback) {
     }, []);
 
     return all(collection);
-  }).then(function () {
+  }).then(function (allPosts) {
+    // Schedule posts that need scheduling
+    scheduleFutures(poet, allPosts);
+
     // Clear out the cached sorted posts, tags, categories, as this point they
     // could have changed from new posts
     clearCache(poet);
@@ -138,7 +141,10 @@ function watch (poet, callback) {
   var watcher = fs.watch(poet.options.posts, function (event, filename) {
     poet.init().then(callback);
   });
-  poet.watchers.push(watcher);
+  poet.watchers.push({
+    'watcher': watcher,
+    'callback': callback
+  });
   return poet;
 }
 exports.watch = watch;
@@ -149,9 +155,38 @@ exports.watch = watch;
  */
 function unwatch (poet) {
   poet.watchers.forEach(function (watcher) {
-    watcher.close();
+    watcher.watcher.close();
+  });
+  poet.futures.forEach(function (future) {
+    clearTimeout(future);
   });
   poet.watchers = [];
+  poet.futures = [];
   return poet;
 }
 exports.unwatch = unwatch;
+
+/**
+ * Schedules a watch event for all posts that are posted in a future date.
+ */
+function scheduleFutures (poet, allPosts) {
+  var now = Date.now();
+  var extraTime = 5 * 1000; // 10 seconds buffer
+  var min = now - extraTime;
+
+  allPosts.forEach(function (post, i) {
+    if (!post) return;
+    var postTime = post.date.getTime();
+
+    // if post is in the future
+    if (postTime - min > 0) {
+      var future = setTimeout(function () {
+        poet.watchers.forEach(function (watcher) {
+          poet.init().then(watcher.callback);
+        });
+      }, postTime - min);
+
+      poet.futures.push(future);
+    }
+  });
+}


### PR DESCRIPTION
If a loaded post have a future date, a timer is set so that all watchers are fired
at (a few seconds after) the time of the post. This allows post scheduling to
happen automatically just by adding future dates.

This addresses issue #66 (opened by myself) in the simplest way I could think of. I haven't added any tests as watching is still untested and I really don't know how to test this. current tests pass.
