### PR TITLE
Add support for Express 4

### DIFF
--- a/lib/poet/routes.js
+++ b/lib/poet/routes.js
@@ -35,9 +35,10 @@ function addRoute (poet, route, handler) {
   var currentRoute = utils.getRoute(routes, type);
   if (currentRoute) {
     // Remove current route
-    poet.app.routes.get.forEach(function (route, index) {
-      if (currentRoute === route.path)
-        poet.app.routes.get.splice(index, 1);
+    poet.app._router.stack.forEach(function (stackItem, index) {
+      if (stackItem.route && stackItem.route.path && stackItem.route.path === route) {
+          poet.app._router.stack.splice(index, 1);
+      }
     });
     // Update options route hash
     delete poet.options.routes[currentRoute];

--- a/lib/poet/utils.js
+++ b/lib/poet/utils.js
@@ -71,7 +71,7 @@ exports.getPostPaths = getPostPaths;
  */
 
 function createLocals (app, helpers) {
-  app.locals(helpers);
+    _.extend(app.locals, helpers);
 }
 exports.createLocals = createLocals;
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "poet",
   "description": "quick and easy blog module, using markdown, jade, whatever",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "main": "lib/poet",
   "dependencies": {
     "marked": "~0.3.2",
@@ -16,7 +16,7 @@
     "mocha": ">= 1.3.2",
     "chai": ">= 1.1.1",
     "supertest": ">= 0.0.1",
-    "express": ">=3.2.4 <4.0.0"
+    "express": ">= 4.0.0"
   },
   "repository": {
     "type": "git",

--- a/test/helpers/routeInfo.js
+++ b/test/helpers/routeInfo.js
@@ -1,11 +1,13 @@
-exports.getCallback = function ( app, path ) {
-  var get_length = app.routes.get ? app.routes.get.length : 0;
+exports.getCallback = function (app, path) {
 
-  for (var i = 0; i < get_length; i++) {
-    if (app.routes.get[i].path == path) {
-      return app.routes.get[i].callbacks[0];
+    if (app._router && app._router.stack) {
+        for (var i = 0; i < app._router.stack.length; i++) {
+            var current = app._router.stack[i];
+            if (current.route && current.route.path && current.route.path == path) {
+                return current.route.stack[0].handle;
+            }
+        }
     }
-  }
 
-  return null;
+    return null;
 }


### PR DESCRIPTION
Express 3 and below are no longer supported
Version bumped to 1.1.0

Based on code by AdamBInfinity https://github.com/jsantell/poet/commit/05e48f43c8db277c03a1dc97ee7e52ec04818a4d
