### PR TITLE
Reintroduce app mounts

### DIFF
--- a/lib/poet/helpers.js
+++ b/lib/poet/helpers.js
@@ -7,15 +7,15 @@ function createHelpers (poet) {
     getCategories: getCategories.bind(null, poet),
     tagURL: function (val) {
       var route = utils.getRoute(options.routes, 'tag');
-      return utils.createURL(route, val);
+      return utils.createURL(poet, route, val);
     },
     categoryURL: function (val) {
       var route = utils.getRoute(options.routes, 'category');
-      return utils.createURL(route, val);
+      return utils.createURL(poet, route, val);
     },
     pageURL: function (val) {
       var route = utils.getRoute(options.routes, 'page');
-      return utils.createURL(route, val);
+      return utils.createURL(poet, route, val);
     },
     getPostCount: function () { return this.getPosts().length; },
     getPost: function (title) { return poet.posts[title]; },

--- a/lib/poet/methods.js
+++ b/lib/poet/methods.js
@@ -68,7 +68,7 @@ function init (poet, callback) {
 
       // Do the templating and adding to poet instance
       // here for access to the file name
-      var post = utils.createPost(file, options).then(function(post) {
+      var post = utils.createPost(poet, file, options).then(function(post) {
         var viewOpts = {
           source: '',
           filename: file,

--- a/lib/poet/utils.js
+++ b/lib/poet/utils.js
@@ -22,18 +22,26 @@ exports.createOptions = createOptions;
 
 /**
  * Takes a `route` string (ex: '/posts/:post') and replaces the parameter with
- * the `value` (ex: '/posts/my-post');
+ * the `value` (ex: '/posts/my-post'). The path created is the absolute
+ * pathname, i.e. in case the Poet app is mounted
+ * (http://expressjs.com/api.html#app.use and
+ * http://expressjs.com/api.html#app.mountpath) the path created has to observe
+ * the mounting point, otherwise created links would be broken.
  *
  * @params {String} route
  * @params {String} value
  * @returns {String}
  */
 
-function createURL (route, value) {
+function createURL (poet, route, value) {
   if (!route) {
     return '';
   }
-  return encodeURI(route.match(/[^\:]*/)[0] + value);
+  var baseURL = encodeURI(route.match(/[^\:]*/)[0] + value);
+  // express 4: mountpath, express 3: route
+  var mount = poet.app && (poet.app.mountpath || poet.app.route);
+  if (mount === "/") mount = null;
+  return mount ? path.join(mount, baseURL) : baseURL;
 }
 exports.createURL = createURL;
 
@@ -148,7 +156,8 @@ function convertStringToSlug(str){
 
 /**
  * Accepts a name of a file and an options hash and returns an object
- * representing a post object
+ * representing a post object. In case we are mounting the poet app (see
+ * comment on createURL()) we need to ensure the `post.url` is relative.
  *
  * @params {String} data
  * @params {String} fileName
@@ -156,18 +165,21 @@ function convertStringToSlug(str){
  * @returns {Object}
  */
 
-function createPost (filePath, options) {
+function createPost (poet, filePath, options) {
   var fileName = path.basename(filePath);
   return fs.readFile(filePath, 'utf-8').then(function (data) {
     var parsed = (options.metaFormat === 'yaml' ? yamlFm : jsonFm)(data);
     var body = parsed.body;
     var post = parsed.attributes;
+    var route = getRoute(options.routes, 'post');
+    var isAbsoluteRoute = !route || route[0] === '/';
+
     // If no date defined, create one for current date
     post.date = new Date(post.date);
     post.content = body;
     // url slug for post
     post.slug = convertStringToSlug(post.slug || post.title);
-    post.url = createURL(getRoute(options.routes, 'post'), post.slug);
+    post.url = createURL(poet, getRoute(options.routes, 'post'), post.slug);
     post.preview = getPreview(post, body, options);
     return post;
   });

--- a/test/helpers.test.js
+++ b/test/helpers.test.js
@@ -48,6 +48,19 @@ describe('helpers[tag|category|page]URL()', function () {
       done();
     }, done);
   });
+  it('mounted paths are respected in [tag|category|page]URL', function (done) {
+    var
+      mainApp = express(),
+      poetApp = express();
+    mainApp.use('/poet-app', poetApp);
+    var poet = Poet(poetApp, { posts: './test/_postsJson' });
+
+    poet.init().then(function () {
+      expect(poet.helpers.categoryURL('phat bass')).to.be.equal('/poet-app/category/phat%20bass');
+      expect(poet.helpers.pageURL('phat bass')).to.be.equal('/poet-app/page/phat%20bass');
+      expect(poet.helpers.tagURL('phat bass')).to.be.equal('/poet-app/tag/phat%20bass');
+    }).then(done, done);
+  });
 });
 
 describe('helpers.getPostCount()', function () {


### PR DESCRIPTION
First introduced with #80 and then reverted with #106 due to express 4 incompatibility. This should be [fixed](https://github.com/rksm/poet/compare/jsantell:master...master#diff-6f7b684383125f18e22692d13cb8641dR42) now.
