### PR TITLE
fixed unneeded use of app.router

### DIFF
--- a/examples/configuredSetup.js
+++ b/examples/configuredSetup.js
@@ -22,7 +22,6 @@ poet.init().then(function () {
 app.set('view engine', 'jade');
 app.set('views', __dirname + '/views');
 app.use(express.static(__dirname + '/public'));
-app.use(app.routes);
 
 app.get('/', function (req, res) { res.render('index');});
 

--- a/examples/defaultSetup.js
+++ b/examples/defaultSetup.js
@@ -11,7 +11,6 @@ poet.init().then(function () {
 app.set('view engine', 'jade');
 app.set('views', __dirname + '/views');
 app.use(express.static(__dirname + '/public'));
-app.use(app.router);
 
 app.get('/', function (req, res) { res.render('index'); });
 

--- a/examples/sitemap.js
+++ b/examples/sitemap.js
@@ -10,7 +10,6 @@ poet.init().then(function () {
 app.set('view engine', 'jade');
 app.set('views', __dirname + '/views');
 app.use(express.static(__dirname + '/public'));
-app.use(app.router);
 
 app.get('/', function (req, res) { res.render('index'); });
 

--- a/examples/watcher.js
+++ b/examples/watcher.js
@@ -13,7 +13,6 @@ poet.watch(function () {
 app.set('view engine', 'jade');
 app.set('views', __dirname + '/views');
 app.use(express.static(__dirname + '/public'));
-app.use(app.router);
 
 app.get('/', function (req, res) { res.render('index'); });
 


### PR DESCRIPTION
Removed from examples unneeded use of app.router. More on this here:
https://github.com/expressjs/express/wiki/Migrating-from-3.x-to-4.x#approuter
