### PR TITLE
Remove example poet sites that are broken from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,8 @@ Full documentation for *Poet* can be found at [http://jsantell.github.io/poet](h
 
 These sites are using Poet for their blogging, check them out! Ping me, or send a PR if you too are using Poet in the wild.
 
-* [Yellow Pages Engineering](http://engineering.yp.com/)
-* [FightMagicRun](http://fightmagicrun.com/blog)
 * [Morgondag](http://morgondag.nu)
 * [DevinYoungWeb.com](http://devinyoungweb.com)
-* [jessehuang.com](http://jessehuang.com)
 * [The Rustual Boy emulator blog](http://rustualboy.com/blog)
 
 ## Installing


### PR DESCRIPTION
To fix https://github.com/jsantell/poet/issues/129 I have removed the links that are broken from the `README.md` file.