### PR TITLE
Minor syntax error fix

### DIFF
--- a/examples/views/includes/pagination.pug
+++ b/examples/views/includes/pagination.pug
@@ -1,7 +1,7 @@
 - var pageCount = getPageCount();
 if pageCount > 1
   ul.pagination
-    var i = 1;
+    - var i = 1;
     while ( i <= pageCount )
       if page == i
         li(class='active')


### PR DESCRIPTION
added the `-` to `var i = 1;` on line 4 to prevent an unwanted `<var>i = 1</var>` tag on the bottom of the index page.